### PR TITLE
Already connected logic

### DIFF
--- a/TikTokLive/client/client.py
+++ b/TikTokLive/client/client.py
@@ -225,7 +225,10 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
         # Wait for the event loop task to finish
         if self._event_loop_task is not None:
-            await self._event_loop_task
+            try:
+                await self._event_loop_task
+            except Exception:
+                self._logger.debug("an exception in event loop is ignored", exc_info=True)
             self._event_loop_task = None
 
         # If recording, stop it

--- a/TikTokLive/client/client.py
+++ b/TikTokLive/client/client.py
@@ -119,7 +119,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
         """
 
-        if self._ws.connected:
+        if self._ws.in_connection_loop:
             raise AlreadyConnectedError("You can only make one connection per client!")
 
         # <Required> Fetch room ID

--- a/TikTokLive/client/client.py
+++ b/TikTokLive/client/client.py
@@ -119,7 +119,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
         """
 
-        if self._ws.in_connection_loop:
+        if self.connected:
             raise AlreadyConnectedError("You can only make one connection per client!")
 
         # <Required> Fetch room ID
@@ -479,7 +479,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
         """
 
-        return self._ws.connected
+        return self._ws.in_connection_loop
 
     @property
     def logger(self) -> logging.Logger:

--- a/TikTokLive/client/ws/ws_client.py
+++ b/TikTokLive/client/ws/ws_client.py
@@ -66,6 +66,10 @@ class WebcastWSClient:
 
         return self.ws and self.ws.open
 
+    @property
+    def in_connection_loop(self) -> bool:
+        return self._connection_generator and self._connection_generator._in_connection_loop
+
     async def send(self, message: Union[bytes, Message]) -> None:
         """
         Send a message to the WebSocket

--- a/TikTokLive/client/ws/ws_connect.py
+++ b/TikTokLive/client/ws/ws_connect.py
@@ -47,6 +47,7 @@ class WebcastConnect(Connect):
         self.logger = self._logger = logger
         self._ws: Optional[WebSocketClientProtocol] = None
         self._initial_response: WebcastResponse = initial_webcast_response
+        self._in_connection_loop: bool = False
 
     @property
     def ws(self) -> Optional[WebSocketClientProtocol]:
@@ -66,6 +67,7 @@ class WebcastConnect(Connect):
         first_connect: bool = True
 
         while True:
+            self._in_connection_loop = True
             try:
 
                 # "async with" yields a WebsocketClientProtocol
@@ -95,6 +97,7 @@ class WebcastConnect(Connect):
                         yield webcast_push_frame, webcast_response
 
             except InvalidStatusCode as ex:
+                self._in_connection_loop = False
                 if ex.status_code == 200:
                     raise WebcastBlocked200Error("WebSocket rejected by TikTok with a 200 status code, implying detection.") from ex
                 raise


### PR DESCRIPTION
# Problem
Currently, whether the TikTokLiveClient is already connected or not is judged by checking whether WebcastConnect._ws is open or not
(judging line https://github.com/isaackogan/TikTokLive/blob/01be8440f831e4b09c0e9599a8e5e39f1f0c7797/TikTokLive/client/client.py#L122-L123)

But the WebcastConnect._ws is set to None in every iteration. Thus, TikTokLiveClient switches between connected and not connected status for the same room.
(set to None in every iteration https://github.com/isaackogan/TikTokLive/blob/01be8440f831e4b09c0e9599a8e5e39f1f0c7797/TikTokLive/client/ws/ws_connect.py#L102-L103)
(TikTokLiveClient switches its status in loop
https://github.com/isaackogan/TikTokLive/blob/01be8440f831e4b09c0e9599a8e5e39f1f0c7797/TikTokLive/client/client.py#L311-L318
)

In cases that TikTokLiveClient.start() task is created when WebcastConnect._ws is set to None, it connect to server for the second time while it is already connected.

# Solution
I introduce WebcastConnect._in_connection_loop variable and it remains True while in the above loop
